### PR TITLE
Modify drawing element error fix

### DIFF
--- a/src/components/annotations.vue
+++ b/src/components/annotations.vue
@@ -1244,7 +1244,12 @@
                     }
               })
             }
-            modifyInter.dispatchEvent(new ol.interaction.Modify.Event("featuresmodified",modifiedFeatures,ev))
+            var event = {
+                type: 'featuresmodified',
+                features: modifiedFeatures,
+                originalEvent: ev
+              };
+              modifyInter.dispatchEvent(event)
           })
           modifyInter.on("featuresmodified",function(ev){
             ev.features.forEach(function(f){

--- a/src/components/drawinglogs.vue
+++ b/src/components/drawinglogs.vue
@@ -320,8 +320,14 @@
                             }
                             f.setGeometry(feature.getGeometry())
                             f.getGeometry().on("change",vm._eventHandlers["geometry:change"](f,feature.get('id')))
-                            vm.annotations.ui.modifyInter.dispatchEvent(new ol.interaction.Modify.Event("featuresmodified",new ol.Collection([f]),null))
-                        }
+                            var modifiedFeatures = new ol.Collection([f]);
+                            var event = {
+                            type: 'featuresmodified',
+                            features: modifiedFeatures,
+                            originalEvent: null
+                            };
+                            vm.annotations.ui.modifyInter.dispatchEvent(event);
+                            }
                     })
                 } else if (vm.drawingLogs[undoIndex][0] === 'P') {
                     //Change feature property log; 


### PR DESCRIPTION
In the testing website, I found out that the Modify/Edit functionality was not working properly.
When Editing a drawing element (moving/changing) throws an error 

This has been fixed in this commit

Changes: modify.Event() is no longer a constructor in open layers. Modified accordingly

